### PR TITLE
Report invalid commandline options without stack trace.

### DIFF
--- a/src/dev_journal/cli.cr
+++ b/src/dev_journal/cli.cr
@@ -124,7 +124,7 @@ module DevJournal
         parser.on("-v", "--version", "Show the version") { abort("Log v#{DevJournal::VERSION}") }
       end
     rescue ex
-      puts ex.message
+      puts abort(ex.message)
     end
 
     def self.run

--- a/src/dev_journal/cli.cr
+++ b/src/dev_journal/cli.cr
@@ -123,6 +123,8 @@ module DevJournal
         parser.on("-h", "--help", "Show this help") { abort(parser) }
         parser.on("-v", "--version", "Show the version") { abort("Log v#{DevJournal::VERSION}") }
       end
+    rescue ex
+      puts ex.message
     end
 
     def self.run


### PR DESCRIPTION
Reporting invalid command line options without a big stack trace makes it a little more polished.
